### PR TITLE
Fix auth grid column names

### DIFF
--- a/Business/AuthManager.cs
+++ b/Business/AuthManager.cs
@@ -76,7 +76,16 @@ namespace Teklif_Hazırlayıcı.Business
             {
 
                 string query = @"
-            SELECT y.yetkili_id, f.isim, y.isim, y.soyisim, y.hitap, y.adres, y.telefon, y.eposta
+            SELECT
+                y.yetkili_id,
+                y.firma_id,
+                f.isim AS Firma,
+                y.isim,
+                y.soyisim,
+                y.hitap,
+                y.adres,
+                y.telefon,
+                y.eposta
             FROM yetkililer y
             LEFT JOIN firmalar f ON y.firma_id = f.firma_id";
 

--- a/Forms/auth.cs
+++ b/Forms/auth.cs
@@ -65,8 +65,8 @@ namespace Teklif_Hazırlayıcı.Forms
         private void LoadAuth()
         {
             dataGridView1.DataSource = _authManager.GetAuthWithCompanyName();
-            //SetupGridColumnProperties();
-            //SetupAuthGridColumns();
+            SetupGridColumnProperties();
+            SetupAuthGridColumns();
         }
 
         private void SetupGridColumnProperties()
@@ -84,10 +84,10 @@ namespace Teklif_Hazırlayıcı.Forms
                 dataGridView1.Columns["firma_id"].Visible = false;
 
             // İstenilen sıraya göre DisplayIndex ayarla
-            if (dataGridView1.Columns["adi"] != null)
+            if (dataGridView1.Columns["Firma"] != null)
             {
-                dataGridView1.Columns["adi"].DisplayIndex = 0;
-                dataGridView1.Columns["adi"].HeaderText = "Deneme";
+                dataGridView1.Columns["Firma"].DisplayIndex = 0;
+                dataGridView1.Columns["Firma"].HeaderText = "Firma Adı";
             }
 
             if (dataGridView1.Columns["isim"] != null)


### PR DESCRIPTION
## Summary
- alias company name when loading auth list
- set auth grid columns correctly and apply on load

## Testing
- `dotnet build "Teklif Hazırlayıcı.sln"` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684bd48d42b88328a2fb8bd11a9ec9a6