### PR TITLE
Add user configurable settings form

### DIFF
--- a/Forms/Editor/settings.Designer.cs
+++ b/Forms/Editor/settings.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace Teklif_Hazırlayıcı.Forms.Editor
+namespace Teklif_Hazırlayıcı.Forms.Editor
 {
     partial class settings
     {
@@ -28,12 +28,245 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
+            this.lblDefaultNote = new System.Windows.Forms.Label();
+            this.txtDefaultNote = new System.Windows.Forms.TextBox();
+            this.lblTheme = new System.Windows.Forms.Label();
+            this.cmbTheme = new System.Windows.Forms.ComboBox();
+            this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.chkEmailApproval = new System.Windows.Forms.CheckBox();
+            this.chkEmailNewOffer = new System.Windows.Forms.CheckBox();
+            this.chkSmsApproval = new System.Windows.Forms.CheckBox();
+            this.chkSmsNewOffer = new System.Windows.Forms.CheckBox();
+            this.picLogo = new System.Windows.Forms.PictureBox();
+            this.btnBrowseLogo = new System.Windows.Forms.Button();
+            this.lblSignature = new System.Windows.Forms.Label();
+            this.txtSignature = new System.Windows.Forms.TextBox();
+            this.lblName = new System.Windows.Forms.Label();
+            this.txtName = new System.Windows.Forms.TextBox();
+            this.lblTitle = new System.Windows.Forms.Label();
+            this.txtTitle = new System.Windows.Forms.TextBox();
+            this.btnSave = new System.Windows.Forms.Button();
+            this.groupBox1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.picLogo)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // lblDefaultNote
+            // 
+            this.lblDefaultNote.AutoSize = true;
+            this.lblDefaultNote.Location = new System.Drawing.Point(12, 15);
+            this.lblDefaultNote.Name = "lblDefaultNote";
+            this.lblDefaultNote.Size = new System.Drawing.Size(99, 13);
+            this.lblDefaultNote.TabIndex = 0;
+            this.lblDefaultNote.Text = "Varsayılan Açıklama";
+            // 
+            // txtDefaultNote
+            // 
+            this.txtDefaultNote.Location = new System.Drawing.Point(150, 12);
+            this.txtDefaultNote.Multiline = true;
+            this.txtDefaultNote.Name = "txtDefaultNote";
+            this.txtDefaultNote.Size = new System.Drawing.Size(300, 60);
+            this.txtDefaultNote.TabIndex = 1;
+            // 
+            // lblTheme
+            // 
+            this.lblTheme.AutoSize = true;
+            this.lblTheme.Location = new System.Drawing.Point(12, 86);
+            this.lblTheme.Name = "lblTheme";
+            this.lblTheme.Size = new System.Drawing.Size(34, 13);
+            this.lblTheme.TabIndex = 2;
+            this.lblTheme.Text = "Tema";
+            // 
+            // cmbTheme
+            // 
+            this.cmbTheme.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbTheme.FormattingEnabled = true;
+            this.cmbTheme.Items.AddRange(new object[] {
+            "Light",
+            "Dark"});
+            this.cmbTheme.Location = new System.Drawing.Point(150, 83);
+            this.cmbTheme.Name = "cmbTheme";
+            this.cmbTheme.Size = new System.Drawing.Size(121, 21);
+            this.cmbTheme.TabIndex = 3;
+            // 
+            // groupBox1
+            // 
+            this.groupBox1.Controls.Add(this.chkSmsNewOffer);
+            this.groupBox1.Controls.Add(this.chkSmsApproval);
+            this.groupBox1.Controls.Add(this.chkEmailNewOffer);
+            this.groupBox1.Controls.Add(this.chkEmailApproval);
+            this.groupBox1.Location = new System.Drawing.Point(15, 120);
+            this.groupBox1.Name = "groupBox1";
+            this.groupBox1.Size = new System.Drawing.Size(435, 70);
+            this.groupBox1.TabIndex = 4;
+            this.groupBox1.TabStop = false;
+            this.groupBox1.Text = "Bildirimler";
+            // 
+            // chkEmailApproval
+            // 
+            this.chkEmailApproval.AutoSize = true;
+            this.chkEmailApproval.Location = new System.Drawing.Point(6, 19);
+            this.chkEmailApproval.Name = "chkEmailApproval";
+            this.chkEmailApproval.Size = new System.Drawing.Size(157, 17);
+            this.chkEmailApproval.TabIndex = 0;
+            this.chkEmailApproval.Text = "Teklif onayında e-posta";
+            this.chkEmailApproval.UseVisualStyleBackColor = true;
+            // 
+            // chkEmailNewOffer
+            // 
+            this.chkEmailNewOffer.AutoSize = true;
+            this.chkEmailNewOffer.Location = new System.Drawing.Point(6, 42);
+            this.chkEmailNewOffer.Name = "chkEmailNewOffer";
+            this.chkEmailNewOffer.Size = new System.Drawing.Size(146, 17);
+            this.chkEmailNewOffer.TabIndex = 1;
+            this.chkEmailNewOffer.Text = "Yeni teklifte e-posta";
+            this.chkEmailNewOffer.UseVisualStyleBackColor = true;
+            // 
+            // chkSmsApproval
+            // 
+            this.chkSmsApproval.AutoSize = true;
+            this.chkSmsApproval.Location = new System.Drawing.Point(215, 19);
+            this.chkSmsApproval.Name = "chkSmsApproval";
+            this.chkSmsApproval.Size = new System.Drawing.Size(136, 17);
+            this.chkSmsApproval.TabIndex = 2;
+            this.chkSmsApproval.Text = "Teklif onayında SMS";
+            this.chkSmsApproval.UseVisualStyleBackColor = true;
+            // 
+            // chkSmsNewOffer
+            // 
+            this.chkSmsNewOffer.AutoSize = true;
+            this.chkSmsNewOffer.Location = new System.Drawing.Point(215, 42);
+            this.chkSmsNewOffer.Name = "chkSmsNewOffer";
+            this.chkSmsNewOffer.Size = new System.Drawing.Size(125, 17);
+            this.chkSmsNewOffer.TabIndex = 3;
+            this.chkSmsNewOffer.Text = "Yeni teklifte SMS";
+            this.chkSmsNewOffer.UseVisualStyleBackColor = true;
+            // 
+            // picLogo
+            // 
+            this.picLogo.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.picLogo.Location = new System.Drawing.Point(15, 205);
+            this.picLogo.Name = "picLogo";
+            this.picLogo.Size = new System.Drawing.Size(150, 80);
+            this.picLogo.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
+            this.picLogo.TabIndex = 5;
+            this.picLogo.TabStop = false;
+            // 
+            // btnBrowseLogo
+            // 
+            this.btnBrowseLogo.Location = new System.Drawing.Point(171, 262);
+            this.btnBrowseLogo.Name = "btnBrowseLogo";
+            this.btnBrowseLogo.Size = new System.Drawing.Size(75, 23);
+            this.btnBrowseLogo.TabIndex = 6;
+            this.btnBrowseLogo.Text = "Logo Seç";
+            this.btnBrowseLogo.UseVisualStyleBackColor = true;
+            this.btnBrowseLogo.Click += new System.EventHandler(this.btnBrowseLogo_Click);
+            // 
+            // lblSignature
+            // 
+            this.lblSignature.AutoSize = true;
+            this.lblSignature.Location = new System.Drawing.Point(12, 298);
+            this.lblSignature.Name = "lblSignature";
+            this.lblSignature.Size = new System.Drawing.Size(67, 13);
+            this.lblSignature.TabIndex = 7;
+            this.lblSignature.Text = "Dijital İmza";
+            // 
+            // txtSignature
+            // 
+            this.txtSignature.Location = new System.Drawing.Point(150, 295);
+            this.txtSignature.Name = "txtSignature";
+            this.txtSignature.Size = new System.Drawing.Size(300, 20);
+            this.txtSignature.TabIndex = 8;
+            // 
+            // lblName
+            // 
+            this.lblName.AutoSize = true;
+            this.lblName.Location = new System.Drawing.Point(12, 324);
+            this.lblName.Name = "lblName";
+            this.lblName.Size = new System.Drawing.Size(20, 13);
+            this.lblName.TabIndex = 9;
+            this.lblName.Text = "Ad";
+            // 
+            // txtName
+            // 
+            this.txtName.Location = new System.Drawing.Point(150, 321);
+            this.txtName.Name = "txtName";
+            this.txtName.Size = new System.Drawing.Size(300, 20);
+            this.txtName.TabIndex = 10;
+            // 
+            // lblTitle
+            // 
+            this.lblTitle.AutoSize = true;
+            this.lblTitle.Location = new System.Drawing.Point(12, 350);
+            this.lblTitle.Name = "lblTitle";
+            this.lblTitle.Size = new System.Drawing.Size(38, 13);
+            this.lblTitle.TabIndex = 11;
+            this.lblTitle.Text = "Ünvan";
+            // 
+            // txtTitle
+            // 
+            this.txtTitle.Location = new System.Drawing.Point(150, 347);
+            this.txtTitle.Name = "txtTitle";
+            this.txtTitle.Size = new System.Drawing.Size(300, 20);
+            this.txtTitle.TabIndex = 12;
+            // 
+            // btnSave
+            // 
+            this.btnSave.Location = new System.Drawing.Point(375, 385);
+            this.btnSave.Name = "btnSave";
+            this.btnSave.Size = new System.Drawing.Size(75, 23);
+            this.btnSave.TabIndex = 13;
+            this.btnSave.Text = "Kaydet";
+            this.btnSave.UseVisualStyleBackColor = true;
+            this.btnSave.Click += new System.EventHandler(this.btnSave_Click);
+            // 
+            // settings
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(800, 450);
-            this.Text = "settings";
+            this.ClientSize = new System.Drawing.Size(469, 420);
+            this.Controls.Add(this.btnSave);
+            this.Controls.Add(this.txtTitle);
+            this.Controls.Add(this.lblTitle);
+            this.Controls.Add(this.txtName);
+            this.Controls.Add(this.lblName);
+            this.Controls.Add(this.txtSignature);
+            this.Controls.Add(this.lblSignature);
+            this.Controls.Add(this.btnBrowseLogo);
+            this.Controls.Add(this.picLogo);
+            this.Controls.Add(this.groupBox1);
+            this.Controls.Add(this.cmbTheme);
+            this.Controls.Add(this.lblTheme);
+            this.Controls.Add(this.txtDefaultNote);
+            this.Controls.Add(this.lblDefaultNote);
+            this.Name = "settings";
+            this.Text = "Ayarlar";
+            this.Load += new System.EventHandler(this.settings_Load);
+            this.groupBox1.ResumeLayout(false);
+            this.groupBox1.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.picLogo)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
         }
 
         #endregion
+
+        private System.Windows.Forms.Label lblDefaultNote;
+        private System.Windows.Forms.TextBox txtDefaultNote;
+        private System.Windows.Forms.Label lblTheme;
+        private System.Windows.Forms.ComboBox cmbTheme;
+        private System.Windows.Forms.GroupBox groupBox1;
+        private System.Windows.Forms.CheckBox chkSmsNewOffer;
+        private System.Windows.Forms.CheckBox chkSmsApproval;
+        private System.Windows.Forms.CheckBox chkEmailNewOffer;
+        private System.Windows.Forms.CheckBox chkEmailApproval;
+        private System.Windows.Forms.PictureBox picLogo;
+        private System.Windows.Forms.Button btnBrowseLogo;
+        private System.Windows.Forms.Label lblSignature;
+        private System.Windows.Forms.TextBox txtSignature;
+        private System.Windows.Forms.Label lblName;
+        private System.Windows.Forms.TextBox txtName;
+        private System.Windows.Forms.Label lblTitle;
+        private System.Windows.Forms.TextBox txtTitle;
+        private System.Windows.Forms.Button btnSave;
     }
 }

--- a/Forms/Editor/settings.cs
+++ b/Forms/Editor/settings.cs
@@ -7,6 +7,9 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using System.IO;
+using Teklif_Hazırlayıcı.Properties;
+using Teklif_Hazırlayıcı.Helpers;
 
 namespace Teklif_Hazırlayıcı.Forms.Editor
 {
@@ -15,6 +18,56 @@ namespace Teklif_Hazırlayıcı.Forms.Editor
         public settings()
         {
             InitializeComponent();
+        }
+
+        private void settings_Load(object sender, EventArgs e)
+        {
+            txtDefaultNote.Text = Settings.Default.DefaultNote;
+            cmbTheme.SelectedItem = Settings.Default.Theme;
+            chkEmailApproval.Checked = Settings.Default.NotifyOnApprovalEmail;
+            chkEmailNewOffer.Checked = Settings.Default.NotifyOnNewOfferEmail;
+            chkSmsApproval.Checked = Settings.Default.NotifyOnApprovalSMS;
+            chkSmsNewOffer.Checked = Settings.Default.NotifyOnNewOfferSMS;
+            txtSignature.Text = Settings.Default.DigitalSignature;
+            txtName.Text = Settings.Default.DigitalName;
+            txtTitle.Text = Settings.Default.DigitalTitle;
+
+            if (File.Exists(Settings.Default.CompanyLogoPath))
+                picLogo.ImageLocation = Settings.Default.CompanyLogoPath;
+        }
+
+        private void btnBrowseLogo_Click(object sender, EventArgs e)
+        {
+            using (OpenFileDialog ofd = new OpenFileDialog())
+            {
+                ofd.Filter = "Image Files|*.png;*.jpg;*.jpeg;*.bmp";
+                if (ofd.ShowDialog() == DialogResult.OK)
+                {
+                    picLogo.ImageLocation = ofd.FileName;
+                }
+            }
+        }
+
+        private void btnSave_Click(object sender, EventArgs e)
+        {
+            Settings.Default.DefaultNote = txtDefaultNote.Text;
+            Settings.Default.Theme = cmbTheme.SelectedItem?.ToString() ?? "Light";
+            Settings.Default.NotifyOnApprovalEmail = chkEmailApproval.Checked;
+            Settings.Default.NotifyOnNewOfferEmail = chkEmailNewOffer.Checked;
+            Settings.Default.NotifyOnApprovalSMS = chkSmsApproval.Checked;
+            Settings.Default.NotifyOnNewOfferSMS = chkSmsNewOffer.Checked;
+            Settings.Default.DigitalSignature = txtSignature.Text;
+            Settings.Default.DigitalName = txtName.Text;
+            Settings.Default.DigitalTitle = txtTitle.Text;
+            Settings.Default.CompanyLogoPath = picLogo.ImageLocation ?? string.Empty;
+
+            Settings.Default.Save();
+
+            bool dark = Settings.Default.Theme.Equals("Dark", StringComparison.OrdinalIgnoreCase);
+            ThemeManager.ApplyThemeToAllOpenForms(dark);
+
+            MessageBox.Show("Ayarlar kaydedildi.");
+            Close();
         }
     }
 }

--- a/Helpers/ThemeManager.cs
+++ b/Helpers/ThemeManager.cs
@@ -15,7 +15,12 @@ namespace Teklif_Hazırlayıcı.Helpers
 
         public static void ToggleTheme(Form form)
         {
-            _isDarkMode = !_isDarkMode;
+            SetTheme(form, !_isDarkMode);
+        }
+
+        public static void SetTheme(Form form, bool darkMode)
+        {
+            _isDarkMode = darkMode;
 
             Color darkBackground = Color.FromArgb(40, 40, 40);
             Color lightBackground = Color.FromArgb(0, 56, 64);
@@ -26,6 +31,14 @@ namespace Teklif_Hazırlayıcı.Helpers
             StartBackgroundTransition(form, fromColor, toColor);
 
             ApplyTheme(form);
+        }
+
+        public static void ApplyThemeToAllOpenForms(bool darkMode)
+        {
+            foreach (Form form in Application.OpenForms)
+            {
+                SetTheme(form, darkMode);
+            }
         }
 
 

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -45,5 +45,125 @@ namespace Teklif_Hazırlayıcı.Properties {
                 this["kullanici_id"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string DefaultNote {
+            get {
+                return ((string)(this["DefaultNote"]));
+            }
+            set {
+                this["DefaultNote"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("Light")]
+        public string Theme {
+            get {
+                return ((string)(this["Theme"]));
+            }
+            set {
+                this["Theme"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool NotifyOnApprovalEmail {
+            get {
+                return ((bool)(this["NotifyOnApprovalEmail"]));
+            }
+            set {
+                this["NotifyOnApprovalEmail"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool NotifyOnNewOfferEmail {
+            get {
+                return ((bool)(this["NotifyOnNewOfferEmail"]));
+            }
+            set {
+                this["NotifyOnNewOfferEmail"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool NotifyOnApprovalSMS {
+            get {
+                return ((bool)(this["NotifyOnApprovalSMS"]));
+            }
+            set {
+                this["NotifyOnApprovalSMS"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool NotifyOnNewOfferSMS {
+            get {
+                return ((bool)(this["NotifyOnNewOfferSMS"]));
+            }
+            set {
+                this["NotifyOnNewOfferSMS"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string CompanyLogoPath {
+            get {
+                return ((string)(this["CompanyLogoPath"]));
+            }
+            set {
+                this["CompanyLogoPath"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string DigitalSignature {
+            get {
+                return ((string)(this["DigitalSignature"]));
+            }
+            set {
+                this["DigitalSignature"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string DigitalName {
+            get {
+                return ((string)(this["DigitalName"]));
+            }
+            set {
+                this["DigitalName"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string DigitalTitle {
+            get {
+                return ((string)(this["DigitalTitle"]));
+            }
+            set {
+                this["DigitalTitle"] = value;
+            }
+        }
     }
 }

--- a/Properties/Settings.settings
+++ b/Properties/Settings.settings
@@ -13,5 +13,35 @@
     <Setting Name="kullanici_id" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">0</Value>
     </Setting>
+    <Setting Name="DefaultNote" Type="System.String" Scope="User">
+      <Value Profile="(Default)"></Value>
+    </Setting>
+    <Setting Name="Theme" Type="System.String" Scope="User">
+      <Value Profile="(Default)">Light</Value>
+    </Setting>
+    <Setting Name="NotifyOnApprovalEmail" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="NotifyOnNewOfferEmail" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="NotifyOnApprovalSMS" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="NotifyOnNewOfferSMS" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="CompanyLogoPath" Type="System.String" Scope="User">
+      <Value Profile="(Default)"></Value>
+    </Setting>
+    <Setting Name="DigitalSignature" Type="System.String" Scope="User">
+      <Value Profile="(Default)"></Value>
+    </Setting>
+    <Setting Name="DigitalName" Type="System.String" Scope="User">
+      <Value Profile="(Default)"></Value>
+    </Setting>
+    <Setting Name="DigitalTitle" Type="System.String" Scope="User">
+      <Value Profile="(Default)"></Value>
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
## Summary
- expand Properties settings with theme, notes, notifications and branding info
- generate matching Settings.Designer members
- extend ThemeManager to set themes for all open forms
- redesign settings form and implement load/save logic

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fc932e5e483289fecdfeb403dc36d