### PR TITLE
Add post-publish Git update script

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@
 3. Müşteri ve ürün bilgilerini girin.
 4. Teklifi kaydedin ve PDF olarak dışa aktarın.
 
+## Yayımlama Sonrası Otomatik Güncelleme
+
+Uygulama yayımlandıktan sonra oluşan değişikliklerin sürüm kontrolüne
+otomatik olarak eklenmesi için `scripts/post_publish_git_update.sh` betiğini
+çalıştırabilirsiniz:
+
+```bash
+./scripts/post_publish_git_update.sh
+```
+
+Betik, depoda yer alan değişiklikleri commit eder ve bir uzak depo tanımlıysa
+push işlemini de gerçekleştirir.
+
 ## Katkıda Bulunma
 
 Katkılarınızı memnuniyetle karşılıyoruz! Lütfen aşağıdaki adımları izleyerek katkıda bulunabilirsiniz:

--- a/scripts/post_publish_git_update.sh
+++ b/scripts/post_publish_git_update.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Automatically commit and push changes after publishing
+
+set -e
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || { echo "Not a git repository"; exit 1; }
+cd "$repo_root"
+
+changes="$(git status --porcelain)"
+if [ -z "$changes" ]; then
+    echo "No changes to commit."
+    exit 0
+fi
+
+# Stage all changes
+git add -A
+
+# Commit with a generic message
+git commit -m "Update build artifacts after publish"
+
+# Push if a remote is configured
+if git remote get-url origin > /dev/null 2>&1; then
+    git push
+else
+    echo "No remote configured, skipping push."
+fi


### PR DESCRIPTION
## Summary
- add `post_publish_git_update.sh` to automatically commit and push changes after publishing
- update README with instructions for running the script

## Testing
- `bash -n scripts/post_publish_git_update.sh`

------
https://chatgpt.com/codex/tasks/task_e_684ffa35da9083288d1141ad7bd503ce