### PR TITLE
Improve update security

### DIFF
--- a/Helpers/UpdateHelper.cs
+++ b/Helpers/UpdateHelper.cs
@@ -2,7 +2,11 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Net;
+using System.Net.Http;
+using System.Net.Security;
 using System.Reflection;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using System.Windows.Forms;
 using System.IO.Compression;
 
@@ -12,13 +16,29 @@ namespace Teklif_Hazırlayıcı.Helpers
     {
         private const string VersionInfoUrl = "https://raw.githubusercontent.com/hakanicellioglu/teklif-hazirlayici/main/version.txt";
 
+        private static HttpClient CreateSecureClient()
+        {
+            var handler = new HttpClientHandler();
+            handler.ServerCertificateCustomValidationCallback = (request, certificate, chain, sslPolicyErrors) =>
+            {
+                return sslPolicyErrors == SslPolicyErrors.None;
+            };
+            return new HttpClient(handler);
+        }
+
         public static void CheckForUpdates()
         {
             try
             {
-                using (var client = new WebClient())
+                using (var client = CreateSecureClient())
                 {
-                    string versionContent = client.DownloadString(VersionInfoUrl);
+                    if (!VersionInfoUrl.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+                    {
+                        MessageHelper.ShowError("Güncelleme adresi güvenli değil. HTTPS kullanılmalıdır.");
+                        return;
+                    }
+
+                    string versionContent = client.GetStringAsync(VersionInfoUrl).Result;
                     string[] lines = versionContent
                         .Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries);
 
@@ -31,6 +51,7 @@ namespace Teklif_Hazırlayıcı.Helpers
                     string versionLine = lines[0].Replace("\uFEFF", "").Trim();
                     string versionString = versionLine.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries)[0];
                     string zipUrl = lines.Length > 1 ? lines[1].Trim() : string.Empty;
+                    string expectedHash = lines.Length > 2 ? lines[2].Trim() : null;
 
                     if (!Version.TryParse(versionString, out Version latestVersion))
                     {
@@ -65,8 +86,30 @@ namespace Teklif_Hazırlayıcı.Helpers
                             if (string.IsNullOrEmpty(zipUrl))
                                 zipUrl = $"https://github.com/hakanicellioglu/teklif-hazirlayici/releases/download/{versionString}/publish.zip";
 
+                            if (!zipUrl.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+                            {
+                                MessageHelper.ShowError("Güncelleme adresi güvenli değil. HTTPS kullanılmalıdır.");
+                                return;
+                            }
+
                             Debug.WriteLine($"[İNDİRME] Güncelleme arşivi indiriliyor: {zipUrl}");
-                            client.DownloadFile(zipUrl, zipPath);
+                            var zipBytes = client.GetByteArrayAsync(zipUrl).Result;
+                            File.WriteAllBytes(zipPath, zipBytes);
+
+                            if (!string.IsNullOrEmpty(expectedHash))
+                            {
+                                using (var sha256 = SHA256.Create())
+                                using (var fs = File.OpenRead(zipPath))
+                                {
+                                    var actual = sha256.ComputeHash(fs);
+                                    string actualHash = BitConverter.ToString(actual).Replace("-", "").ToLowerInvariant();
+                                    if (!string.Equals(actualHash, expectedHash, StringComparison.OrdinalIgnoreCase))
+                                    {
+                                        MessageHelper.ShowError("İndirilen dosyanın bütünlük doğrulaması başarısız. Güncelleme iptal edildi.");
+                                        return;
+                                    }
+                                }
+                            }
 
                             Debug.WriteLine($"[AÇMA] Zip içeriği çıkarılıyor: {tempDir}");
                             ZipFile.ExtractToDirectory(zipPath, tempDir);

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - **PDF Oluşturma**: Hazırlanan teklifleri PDF formatında dışa aktararak paylaşımı kolaylaştırır.
 - **Şablon Desteği**: Farklı teklif şablonları ile özelleştirilmiş teklifler oluşturabilirsiniz.
 - **Otomatik Güncelleme**: Uygulama açılışta en son sürümü kontrol eder ve gerekirse güncellemeyi indirip yükler.
+- **Otomatik Güncelleme**: Uygulama açılışta en son sürümü kontrol eder ve gerekirse güncellemeyi indirip yükler. İndirilen arşivin SHA256 değeri `version.txt` dosyasında belirtilir ve dosya doğrulaması başarısız olursa güncelleme iptal edilir.
 
 ## Kurulum
 
@@ -25,10 +26,14 @@
 
 4. **Bağlantı Dizesini Tanımlayın**:
    - `SQL_CONN_STRING` ortam değişkenini kendi veritabanı bilgilerinizle ayarlayın **veya**
-     `App.config` ile aynı klasörde `App.config.user` dosyası oluşturarak `SqlConnectionString` değerini burada belirtin.
-
+   `App.config` ile aynı klasörde `App.config.user` dosyası oluşturarak `SqlConnectionString` değerini burada belirtin.
 5. **Projeyi Derleyin ve Çalıştırın**:
    - Projeyi derleyin ve uygulamayı başlatın.
+
+Güncellemelerin kontrol edildiği `version.txt` dosyası üç satırdan oluşur:
+1. Sürüm numarası
+2. Güncelleme paketinin HTTPS adresi
+3. `publish.zip` dosyasının SHA256 özeti
 
 ## Kullanım
 


### PR DESCRIPTION
## Summary
- verify update packages with SHA256
- enforce HTTPS and validate certificate chains during downloads
- document new version.txt format

## Testing
- `dotnet build 'Teklif Hazırlayıcı.sln'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68515de969108328bbb8fec1e8c4b32d