### PR TITLE
Add configurable logging

### DIFF
--- a/DataAccess/DatabaseInitializer.cs
+++ b/DataAccess/DatabaseInitializer.cs
@@ -59,6 +59,7 @@ namespace Teklif_Hazırlayıcı.DataAccess
             }
             catch (Exception ex)
             {
+                Logger.Log(ex);
                 MessageHelper.ShowError($"[HATA] Veritabanı başlatılırken sorun oluştu: {ex.Message}");
             }
         }

--- a/Forms/Editor/settings.Designer.cs
+++ b/Forms/Editor/settings.Designer.cs
@@ -45,6 +45,9 @@ namespace Teklif_Hazırlayıcı.Forms.Editor
             this.txtName = new System.Windows.Forms.TextBox();
             this.lblTitle = new System.Windows.Forms.Label();
             this.txtTitle = new System.Windows.Forms.TextBox();
+            this.lblLogDirectory = new System.Windows.Forms.Label();
+            this.txtLogDirectory = new System.Windows.Forms.TextBox();
+            this.btnBrowseLogDir = new System.Windows.Forms.Button();
             this.btnSave = new System.Windows.Forms.Button();
             this.groupBox1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.picLogo)).BeginInit();
@@ -203,18 +206,44 @@ namespace Teklif_Hazırlayıcı.Forms.Editor
             this.lblTitle.Text = "Ünvan";
             // 
             // txtTitle
-            // 
+            //
             this.txtTitle.Location = new System.Drawing.Point(150, 347);
             this.txtTitle.Name = "txtTitle";
             this.txtTitle.Size = new System.Drawing.Size(300, 20);
             this.txtTitle.TabIndex = 12;
-            // 
+            //
+            // lblLogDirectory
+            //
+            this.lblLogDirectory.AutoSize = true;
+            this.lblLogDirectory.Location = new System.Drawing.Point(12, 373);
+            this.lblLogDirectory.Name = "lblLogDirectory";
+            this.lblLogDirectory.Size = new System.Drawing.Size(65, 13);
+            this.lblLogDirectory.TabIndex = 13;
+            this.lblLogDirectory.Text = "Log Klasörü";
+            //
+            // txtLogDirectory
+            //
+            this.txtLogDirectory.Location = new System.Drawing.Point(150, 370);
+            this.txtLogDirectory.Name = "txtLogDirectory";
+            this.txtLogDirectory.Size = new System.Drawing.Size(219, 20);
+            this.txtLogDirectory.TabIndex = 14;
+            //
+            // btnBrowseLogDir
+            //
+            this.btnBrowseLogDir.Location = new System.Drawing.Point(375, 368);
+            this.btnBrowseLogDir.Name = "btnBrowseLogDir";
+            this.btnBrowseLogDir.Size = new System.Drawing.Size(75, 23);
+            this.btnBrowseLogDir.TabIndex = 15;
+            this.btnBrowseLogDir.Text = "Gözat";
+            this.btnBrowseLogDir.UseVisualStyleBackColor = true;
+            this.btnBrowseLogDir.Click += new System.EventHandler(this.btnBrowseLogDir_Click);
+            //
             // btnSave
-            // 
-            this.btnSave.Location = new System.Drawing.Point(375, 385);
+            //
+            this.btnSave.Location = new System.Drawing.Point(375, 415);
             this.btnSave.Name = "btnSave";
             this.btnSave.Size = new System.Drawing.Size(75, 23);
-            this.btnSave.TabIndex = 13;
+            this.btnSave.TabIndex = 16;
             this.btnSave.Text = "Kaydet";
             this.btnSave.UseVisualStyleBackColor = true;
             this.btnSave.Click += new System.EventHandler(this.btnSave_Click);
@@ -223,8 +252,11 @@ namespace Teklif_Hazırlayıcı.Forms.Editor
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(469, 420);
+            this.ClientSize = new System.Drawing.Size(469, 450);
             this.Controls.Add(this.btnSave);
+            this.Controls.Add(this.btnBrowseLogDir);
+            this.Controls.Add(this.txtLogDirectory);
+            this.Controls.Add(this.lblLogDirectory);
             this.Controls.Add(this.txtTitle);
             this.Controls.Add(this.lblTitle);
             this.Controls.Add(this.txtName);
@@ -270,6 +302,9 @@ namespace Teklif_Hazırlayıcı.Forms.Editor
         private System.Windows.Forms.TextBox txtName;
         private System.Windows.Forms.Label lblTitle;
         private System.Windows.Forms.TextBox txtTitle;
+        private System.Windows.Forms.Label lblLogDirectory;
+        private System.Windows.Forms.TextBox txtLogDirectory;
+        private System.Windows.Forms.Button btnBrowseLogDir;
         private System.Windows.Forms.Button btnSave;
     }
 }

--- a/Forms/Editor/settings.cs
+++ b/Forms/Editor/settings.cs
@@ -33,6 +33,7 @@ namespace Teklif_Hazırlayıcı.Forms.Editor
             txtSignature.Text = Settings.Default.DigitalSignature;
             txtName.Text = Settings.Default.DigitalName;
             txtTitle.Text = Settings.Default.DigitalTitle;
+            txtLogDirectory.Text = Settings.Default.LogDirectory;
 
             if (File.Exists(Settings.Default.CompanyLogoPath))
                 picLogo.ImageLocation = Settings.Default.CompanyLogoPath;
@@ -50,6 +51,17 @@ namespace Teklif_Hazırlayıcı.Forms.Editor
             }
         }
 
+        private void btnBrowseLogDir_Click(object sender, EventArgs e)
+        {
+            using (FolderBrowserDialog fbd = new FolderBrowserDialog())
+            {
+                if (fbd.ShowDialog() == DialogResult.OK)
+                {
+                    txtLogDirectory.Text = fbd.SelectedPath;
+                }
+            }
+        }
+
         private void btnSave_Click(object sender, EventArgs e)
         {
             Settings.Default.DefaultNote = txtDefaultNote.Text;
@@ -62,6 +74,7 @@ namespace Teklif_Hazırlayıcı.Forms.Editor
             Settings.Default.DigitalName = txtName.Text;
             Settings.Default.DigitalTitle = txtTitle.Text;
             Settings.Default.CompanyLogoPath = picLogo.ImageLocation ?? string.Empty;
+            Settings.Default.LogDirectory = txtLogDirectory.Text;
 
             TeklifHazirlayici.Properties.Settings.Default.Save();
 

--- a/Helpers/Logger.cs
+++ b/Helpers/Logger.cs
@@ -1,0 +1,40 @@
+using System;
+using System.IO;
+using TeklifHazirlayici.Properties;
+
+namespace Teklif_Hazırlayıcı.Helpers
+{
+    public static class Logger
+    {
+        private static string GetLogDirectory()
+        {
+            string dir = Settings.Default.LogDirectory;
+            if (string.IsNullOrWhiteSpace(dir))
+            {
+                string appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+                dir = Path.Combine(appData, "TeklifHazirlayici", "logs");
+            }
+            return dir;
+        }
+
+        public static void Log(string message)
+        {
+            try
+            {
+                var directory = GetLogDirectory();
+                Directory.CreateDirectory(directory);
+                string filePath = Path.Combine(directory, $"{DateTime.Now:yyyyMMdd}.log");
+                File.AppendAllText(filePath, $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] {message}{Environment.NewLine}");
+            }
+            catch
+            {
+                // I/O hataları göz ardı edilir
+            }
+        }
+
+        public static void Log(Exception ex)
+        {
+            Log($"Exception: {ex}");
+        }
+    }
+}

--- a/Helpers/MessageHelper.cs
+++ b/Helpers/MessageHelper.cs
@@ -17,6 +17,7 @@ namespace Teklif_Hazırlayıcı.Helpers
 
         public static void ShowError(string message)
         {
+            Logger.Log(message);
             MessageBox.Show(message, title, MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
 

--- a/Program.cs
+++ b/Program.cs
@@ -36,6 +36,7 @@ namespace Teklif_Hazırlayıcı
             }
             catch (Exception ex)
             {
+                Logger.Log(ex);
                 MessageHelper.ShowError($"Hata oluştu: {ex.Message}");
             }
         }

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -165,5 +165,17 @@ namespace TeklifHazirlayici.Properties {
                 this["DigitalTitle"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string LogDirectory {
+            get {
+                return ((string)(this["LogDirectory"]));
+            }
+            set {
+                this["LogDirectory"] = value;
+            }
+        }
     }
 }

--- a/Properties/Settings.settings
+++ b/Properties/Settings.settings
@@ -43,5 +43,8 @@
     <Setting Name="DigitalTitle" Type="System.String" Scope="User">
       <Value Profile="(Default)"></Value>
     </Setting>
+    <Setting Name="LogDirectory" Type="System.String" Scope="User">
+      <Value Profile="(Default)"></Value>
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
## Summary
- add new Logger helper with user directory logic
- log errors via `MessageHelper` and key catch blocks
- expose `LogDirectory` user setting and integrate into settings form

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685160b865cc8328ae6c7c7431fac40b