### PR TITLE
Fix version parsing for update check

### DIFF
--- a/Helpers/UpdateHelper.cs
+++ b/Helpers/UpdateHelper.cs
@@ -168,7 +168,8 @@ namespace Teklif_Hazırlayıcı.Helpers
                     }
 
                     string versionLine = lines[0].Replace("\uFEFF", "").Trim();
-                    string versionString = versionLine.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries)[0];
+                    Match verMatch = Regex.Match(versionLine, @"\d+\.\d+\.\d+(?:\.\d+)?");
+                    string versionString = verMatch.Success ? verMatch.Value : versionLine;
                     string zipUrl = lines.Length > 1 ? lines[1].Trim() : string.Empty;
                     string expectedHash = lines.Length > 2 ? lines[2].Trim() : null;
 


### PR DESCRIPTION
## Summary
- make update check more robust when version info includes extra text

## Testing
- `dotnet test` *(fails: command not found)*
- `msbuild /t:Build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853fb0faa108328aa65b0f245f7885c