### PR TITLE
Fix updater leaving old process running

### DIFF
--- a/Helpers/UpdateHelper.cs
+++ b/Helpers/UpdateHelper.cs
@@ -88,7 +88,14 @@ namespace Teklif_Hazırlayıcı.Helpers
                 UseShellExecute = false
             });
             Application.Exit();
-            Environment.Exit(0);
+            try
+            {
+                Process.GetCurrentProcess().Kill();
+            }
+            catch
+            {
+                Environment.Exit(0);
+            }
         }
 
 


### PR DESCRIPTION
## Summary
- ensure updater terminates old process by killing after Application.Exit

## Testing
- `dotnet build 'Teklif Hazırlayıcı.csproj' -c Release` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685409ede85c8328b6b6eb9fb6c55e9f