### PR TITLE
Sınıf adlarını güncelle ve isimlendirme standartlarına uyum sağla

### DIFF
--- a/Business/itemManager.cs
+++ b/Business/itemManager.cs
@@ -12,7 +12,7 @@ using System.Data.SqlClient;
 
 namespace Teklif_Hazırlayıcı.Business
 {
-    public class itemManager
+    public class ItemManager
     {
         /*
         *
@@ -21,7 +21,7 @@ namespace Teklif_Hazırlayıcı.Business
         *
         */
         private readonly DataAccess.SqlDbConnection _connection;
-        public itemManager()
+        public ItemManager()
         {
             /*
              *

--- a/Forms/Editor/itemEditor.cs
+++ b/Forms/Editor/itemEditor.cs
@@ -17,9 +17,9 @@ namespace Teklif_Hazırlayıcı.Forms.Editor
     {
         int? teklif_id, kalem_id;
         string kategori, editor_mode;
-        private readonly itemManager _itemManager;
+        private readonly ItemManager _itemManager;
 
-        public itemEditor(int? teklifId, int? kalemId, string editMode, itemManager itemManager)
+        public itemEditor(int? teklifId, int? kalemId, string editMode, ItemManager itemManager)
         {
             InitializeComponent();
             bool dark = Settings.Default.Theme.Equals("Dark", StringComparison.OrdinalIgnoreCase);

--- a/Forms/Editor/offerEditor.cs
+++ b/Forms/Editor/offerEditor.cs
@@ -152,7 +152,7 @@ namespace Teklif_Hazırlayıcı.Forms.Editor
 
         private void LoadProducts()
         {
-            itemManager itemMgr = new itemManager();
+            ItemManager itemMgr = new ItemManager();
             DataTable dtKalemler = itemMgr.GetItemsByTeklifId(offer_id);
 
             if (dtKalemler != null && dtKalemler.Rows.Count > 0)
@@ -478,7 +478,7 @@ namespace Teklif_Hazırlayıcı.Forms.Editor
                         if (MessageHelper.ShowQuestion("Teklif başarıyla oluşturuldu. Ürün eklemek ister misiniz?") == DialogResult.Yes)
                         {
                             Hide();
-                            itemEditor itemEditor = new itemEditor(teklifId, null, "Add", new itemManager());
+                            itemEditor itemEditor = new itemEditor(teklifId, null, "Add", new ItemManager());
                             if (itemEditor.ShowDialog() == DialogResult.OK)
                             {
                                 offerManager.UpdateOfferById(teklifId);
@@ -535,7 +535,7 @@ namespace Teklif_Hazırlayıcı.Forms.Editor
                     chkTevkifat.Checked,
                     chkDurum.Text);
 
-                itemManager itemMgr = new itemManager();
+                ItemManager itemMgr = new ItemManager();
                 itemMgr.UpdateItemPricesByOffer(offer_id);
                 _offerManager.UpdateOfferById(offer_id);
 
@@ -562,7 +562,7 @@ namespace Teklif_Hazırlayıcı.Forms.Editor
                 if (result == CustomMessageBox.CustomResult.Duzenle)
                 {
                     Hide();
-                    itemEditor editor = new itemEditor(offer_id, kalemId, "Edit", new itemManager());
+                    itemEditor editor = new itemEditor(offer_id, kalemId, "Edit", new ItemManager());
                     editor.Width = Screen.PrimaryScreen.WorkingArea.Width;
                     editor.Height = Screen.PrimaryScreen.WorkingArea.Height;
                     editor.ShowDialog();
@@ -574,7 +574,7 @@ namespace Teklif_Hazırlayıcı.Forms.Editor
                     var confirm = MessageHelper.ShowQuestion("Bu kalemi silmek istediğinize emin misiniz?");
                     if (confirm == DialogResult.Yes)
                     {
-                        itemManager manager = new itemManager();
+                        ItemManager manager = new ItemManager();
                         if (manager.DeleteProductByKalemId(kalemId))
                         {
                             MessageHelper.ShowInfo("Kalem başarıyla silindi.");
@@ -640,7 +640,7 @@ namespace Teklif_Hazırlayıcı.Forms.Editor
 
         private void btnEdit_Click(object sender, EventArgs e)
         {
-            itemEditor itemEditor = new itemEditor(offer_id, null, "Add", new itemManager());
+            itemEditor itemEditor = new itemEditor(offer_id, null, "Add", new ItemManager());
             itemEditor.ShowDialog();
             LoadProducts();
         }

--- a/Teklif Hazırlayıcı.csproj
+++ b/Teklif Hazırlayıcı.csproj
@@ -99,7 +99,7 @@
   <ItemGroup>
     <Compile Include="Business\AuthManager.cs" />
     <Compile Include="Business\CompanyManager.cs" />
-    <Compile Include="Business\itemManager.cs" />
+    <Compile Include="Business\ItemManager.cs" />
     <Compile Include="Business\OfferManager.cs" />
     <Compile Include="Business\ProductManager.cs" />
     <Compile Include="Business\UserManager.cs" />


### PR DESCRIPTION
`itemManager` sınıfı `ItemManager` olarak değiştirildi. `itemEditor` ve `offerEditor` sınıflarında `itemManager` nesneleri de yeni isimlendirme kuralına uygun olarak `ItemManager` olarak güncellendi. Bu değişiklikler, kodun okunabilirliğini artırmak ve C# isimlendirme standartlarına (PascalCase) uymak amacıyla yapıldı.