### PR TITLE
Add print column for offers

### DIFF
--- a/Forms/offer.cs
+++ b/Forms/offer.cs
@@ -141,6 +141,7 @@ namespace Teklif_Hazırlayıcı.Forms
             }
 
             AddExportPdfColumn();
+            AddPrintColumn();
         }
 
         private void AddExportPdfColumn()
@@ -153,6 +154,23 @@ namespace Teklif_Hazırlayıcı.Forms
                 Name = "export_pdf",
                 HeaderText = "PDF",
                 Text = "PDF",
+                UseColumnTextForButtonValue = true,
+                Width = 60
+            };
+            dataGridView1.Columns.Add(btn);
+            btn.DisplayIndex = dataGridView1.Columns.Count - 1;
+        }
+
+        private void AddPrintColumn()
+        {
+            if (dataGridView1.Columns.Contains("print_offer"))
+                return;
+
+            DataGridViewButtonColumn btn = new DataGridViewButtonColumn
+            {
+                Name = "print_offer",
+                HeaderText = "Yazdır",
+                Text = "Yazdır",
                 UseColumnTextForButtonValue = true,
                 Width = 60
             };
@@ -176,6 +194,18 @@ namespace Teklif_Hazırlayıcı.Forms
                         tevkifat = Convert.ToBoolean(val);
                 }
                 await OfferPdfExporter.ExportOfferToPdfAsync(teklifId, tevkifat);
+            }
+            else if (dataGridView1.Columns[e.ColumnIndex].Name == "print_offer")
+            {
+                int teklifId = Convert.ToInt32(dataGridView1.Rows[e.RowIndex].Cells["teklif_id"].Value);
+                bool tevkifat = false;
+                if (dataGridView1.Columns.Contains("tevkifat"))
+                {
+                    object val = dataGridView1.Rows[e.RowIndex].Cells["tevkifat"].Value;
+                    if (val != DBNull.Value)
+                        tevkifat = Convert.ToBoolean(val);
+                }
+                await OfferPdfExporter.PrintOfferAsync(teklifId, tevkifat);
             }
         }
 

--- a/Forms/offer.cs
+++ b/Forms/offer.cs
@@ -146,35 +146,47 @@ namespace Teklif_Hazırlayıcı.Forms
 
         private void AddExportPdfColumn()
         {
+            DataGridViewButtonColumn btn;
             if (dataGridView1.Columns.Contains("export_pdf"))
-                return;
-
-            DataGridViewButtonColumn btn = new DataGridViewButtonColumn
             {
-                Name = "export_pdf",
-                HeaderText = "PDF",
-                Text = "PDF",
-                UseColumnTextForButtonValue = true,
-                Width = 60
-            };
-            dataGridView1.Columns.Add(btn);
+                btn = (DataGridViewButtonColumn)dataGridView1.Columns["export_pdf"];
+            }
+            else
+            {
+                btn = new DataGridViewButtonColumn
+                {
+                    Name = "export_pdf",
+                    HeaderText = "PDF",
+                    Text = "PDF",
+                    UseColumnTextForButtonValue = true,
+                    Width = 60
+                };
+                dataGridView1.Columns.Add(btn);
+            }
+            btn.Visible = true;
             btn.DisplayIndex = dataGridView1.Columns.Count - 1;
         }
 
         private void AddPrintColumn()
         {
+            DataGridViewButtonColumn btn;
             if (dataGridView1.Columns.Contains("print_offer"))
-                return;
-
-            DataGridViewButtonColumn btn = new DataGridViewButtonColumn
             {
-                Name = "print_offer",
-                HeaderText = "Yazdır",
-                Text = "Yazdır",
-                UseColumnTextForButtonValue = true,
-                Width = 60
-            };
-            dataGridView1.Columns.Add(btn);
+                btn = (DataGridViewButtonColumn)dataGridView1.Columns["print_offer"];
+            }
+            else
+            {
+                btn = new DataGridViewButtonColumn
+                {
+                    Name = "print_offer",
+                    HeaderText = "Yazdır",
+                    Text = "Yazdır",
+                    UseColumnTextForButtonValue = true,
+                    Width = 60
+                };
+                dataGridView1.Columns.Add(btn);
+            }
+            btn.Visible = true;
             btn.DisplayIndex = dataGridView1.Columns.Count - 1;
         }
 

--- a/Helpers/OfferPdfExporter.cs
+++ b/Helpers/OfferPdfExporter.cs
@@ -4,6 +4,7 @@ using System;
 using System.Data;
 using System.Globalization;
 using System.IO;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using Teklif_Hazırlayıcı.Business;
@@ -13,7 +14,7 @@ namespace Teklif_Hazırlayıcı.Helpers
 {
     public static class OfferPdfExporter
     {
-        public static async Task ExportOfferToPdfAsync(int offerId, bool tevkifat)
+        public static async Task ExportOfferToPdfAsync(int offerId, bool tevkifat, string filePath = null)
         {
             try
             {
@@ -74,13 +75,18 @@ namespace Teklif_Hazırlayıcı.Helpers
                 string odenecekTutarStr = odenecekTutar.ToString("N2", new CultureInfo("tr-TR"));
                 char doviz_birimi = row["doviz_birimi"] != DBNull.Value ? Convert.ToChar(row["doviz_birimi"]) : '₺';
 
-                SaveFileDialog saveFile = new SaveFileDialog
+                string savePath = filePath;
+                if (string.IsNullOrEmpty(savePath))
                 {
-                    Filter = "PDF dosyası (*.pdf)|*.pdf",
-                    FileName = $"Teklif_{offerId}.pdf"
-                };
-                if (saveFile.ShowDialog() != DialogResult.OK)
-                    return;
+                    SaveFileDialog saveFile = new SaveFileDialog
+                    {
+                        Filter = "PDF dosyası (*.pdf)|*.pdf",
+                        FileName = $"Teklif_{offerId}.pdf"
+                    };
+                    if (saveFile.ShowDialog() != DialogResult.OK)
+                        return;
+                    savePath = saveFile.FileName;
+                }
 
                 BaseFont baseFont;
                 try
@@ -101,7 +107,7 @@ namespace Teklif_Hazırlayıcı.Helpers
                 var smallFont = new iTextSharp.text.Font(baseFont, 5);
 
                 Document doc = new Document(PageSize.A4, 40, 40, 40, 40);
-                PdfWriter.GetInstance(doc, new FileStream(saveFile.FileName, FileMode.Create));
+                PdfWriter.GetInstance(doc, new FileStream(savePath, FileMode.Create));
                 doc.Open();
 
                 string logoPath = Path.Combine(Application.StartupPath, "Forms", "Resources", "logo.jpeg");
@@ -368,7 +374,10 @@ namespace Teklif_Hazırlayıcı.Helpers
                 onayTable.AddCell(musteriCell);
                 doc.Add(onayTable);
                 doc.Close();
-                MessageBox.Show("PDF başarıyla oluşturuldu.", "PDF Çıktısı", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                if (string.IsNullOrEmpty(filePath))
+                {
+                    MessageBox.Show("PDF başarıyla oluşturuldu.", "PDF Çıktısı", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                }
             }
             catch (Exception ex)
             {
@@ -395,6 +404,27 @@ namespace Teklif_Hazırlayıcı.Helpers
         private static string FormatDecimalTr(decimal value, int precision = 2)
         {
             return value.ToString($"N{precision}", new CultureInfo("tr-TR"));
+        }
+
+        public static async Task PrintOfferAsync(int offerId, bool tevkifat)
+        {
+            try
+            {
+                string tempPath = Path.Combine(Path.GetTempPath(), $"Teklif_{offerId}_{Guid.NewGuid():N}.pdf");
+                await ExportOfferToPdfAsync(offerId, tevkifat, tempPath);
+                var psi = new ProcessStartInfo
+                {
+                    FileName = tempPath,
+                    Verb = "print",
+                    UseShellExecute = true,
+                    CreateNoWindow = true
+                };
+                Process.Start(psi);
+            }
+            catch (Exception ex)
+            {
+                MessageHelper.ShowError("Yazdırma başlatılamadı: " + ex.Message);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add optional file path parameter to OfferPdfExporter.ExportOfferToPdfAsync
- add PrintOfferAsync method to generate a temporary PDF and print
- add new Print column to offer grid with handling logic

## Testing
- `dotnet build 'Teklif Hazırlayıcı.sln'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bced0f9948328a4c00af03b821a53