### PR TITLE
Hide LME when disabled

### DIFF
--- a/Business/OfferManager.cs
+++ b/Business/OfferManager.cs
@@ -143,6 +143,7 @@ namespace Teklif_Hazırlayıcı.Business
         t.vade,
         t.vade_farki,
         t.lme,
+        t.lme_goster,
         t.iscilik,
         t.toplam_adet,
         t.toplam_kg,
@@ -208,6 +209,7 @@ namespace Teklif_Hazırlayıcı.Business
         t.vade,
         t.vade_farki,
         t.lme,
+        t.lme_goster,
         t.iscilik,
         t.toplam_adet,
         t.toplam_kg,
@@ -707,7 +709,8 @@ namespace Teklif_Hazırlayıcı.Business
                     t.teklif_sure,
                     t.doviz_kuru,
                     t.vade,
-                    t.vade_farki
+                    t.vade_farki,
+                    t.lme_goster
                 FROM ((teklifler t
                 LEFT JOIN firmalar f ON f.firma_id = t.firma_id)
                 LEFT JOIN yetkililer y ON y.yetkili_id = t.yetkili_id)

--- a/Helpers/OfferPdfExporter.cs
+++ b/Helpers/OfferPdfExporter.cs
@@ -28,9 +28,12 @@ namespace Teklif_Hazırlayıcı.Helpers
 
                 DataTable teklifGenel = await offerManager.GetOfferByIdAsync(offerId);
                 decimal lmeExport = 0;
+                bool lmeGoster = true;
                 if (teklifGenel != null && teklifGenel.Rows.Count > 0)
                 {
                     decimal.TryParse(teklifGenel.Rows[0]["lme"].ToString(), NumberStyles.Any, new CultureInfo("tr-TR"), out lmeExport);
+                    if (teklifGenel.Columns.Contains("lme_goster") && teklifGenel.Rows[0]["lme_goster"] != DBNull.Value)
+                        lmeGoster = Convert.ToBoolean(teklifGenel.Rows[0]["lme_goster"]);
                 }
 
                 var row = teklifDetay.Rows[0];
@@ -253,8 +256,11 @@ namespace Teklif_Hazırlayıcı.Helpers
                 teslimBilgiTable.AddCell(CreateCell(dovizKuru, smallFont));
                 teslimBilgiTable.AddCell(CreateCell("VADE", smallFont));
                 teslimBilgiTable.AddCell(CreateCell(vade, smallFont));
-                teslimBilgiTable.AddCell(CreateCell("LME (" + doviz_birimi + "/ton)", smallFont));
-                teslimBilgiTable.AddCell(CreateCell(lmeExport.ToString("N2", new CultureInfo("tr-TR")), smallFont));
+                if (lmeGoster)
+                {
+                    teslimBilgiTable.AddCell(CreateCell("LME (" + doviz_birimi + "/ton)", smallFont));
+                    teslimBilgiTable.AddCell(CreateCell(lmeExport.ToString("N2", new CultureInfo("tr-TR")), smallFont));
+                }
                 teslimBilgiTable.HorizontalAlignment = Element.ALIGN_LEFT;
 
                 string[,] toplamlar = {


### PR DESCRIPTION
## Summary
- return `lme_goster` in offer queries
- respect `lme_goster` when exporting or printing PDF offers

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bd750a80883288286ec2aed230496